### PR TITLE
fix: support git diff prefixes beyond a/ and b/

### DIFF
--- a/internal/git/parser.go
+++ b/internal/git/parser.go
@@ -42,7 +42,7 @@ func (p *diffParser) parseFile() *FileDiff {
 	}
 
 	diffLine := p.lines[p.current]
-	paths := regexp.MustCompile(`diff --git a/(.*) b/(.*)`).FindStringSubmatch(diffLine)
+	paths := regexp.MustCompile(`diff --git [a-z]/(.*) [a-z]/(.*)`).FindStringSubmatch(diffLine)
 	if len(paths) >= 3 {
 		file.OldPath = paths[1]
 		file.Path = paths[2]


### PR DESCRIPTION
## Summary

Git diff output can use various single-letter prefixes beyond the standard `a/` and `b/` notation. The parser was hardcoded to only match `a/` and `b/`, causing it to fail when encountering other valid prefixes.

## Changes

- Updated regex pattern in `internal/git/parser.go:45` from `a/` and `b/` to `[a-z]/` to support any single-letter prefix
- This enables the parser to handle all valid git diff prefix formats

## Test plan

- Verify parser correctly handles standard `a/` and `b/` prefixes
- Verify parser handles alternative prefixes (e.g., `i/`, `w/`, `c/`, etc.)
- Confirm no regressions in existing diff parsing functionality
